### PR TITLE
Skip quality gates when build manifests are absent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# Local semantic index daemon state
+.memdb/
+
 # pytype static type analyzer
 .pytype/
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -24,10 +24,12 @@ small pipeline:
 4. Ensure the configured base ref is resolvable.
 5. Compute changed files from the merge-base with `HEAD`.
 6. Select a build driver.
-7. Map file categories to Make or Netsuke targets that are actually declared.
-8. Run available quality targets and emit a Claude Code blocking response on
+7. In automatic driver mode, skip repository quality targets when neither
+   `Netsukefile` nor `Makefile` exists.
+8. Map file categories to Make or Netsuke targets that are actually declared.
+9. Run available quality targets and emit a Claude Code blocking response on
    failure.
-9. Run branch-state gates for uncommitted changes, unpushed commits, protected
+10. Run branch-state gates for uncommitted changes, unpushed commits, protected
    branch commit and push avoidance, and PR rebase requirements.
 
 The main state carrier is `HookState`. It keeps user-facing failure output
@@ -44,6 +46,14 @@ The build-driver boundary is represented by `BuildDriver` and
 
 Keep new driver support inside that boundary. Avoid spreading driver-specific
 conditionals across the stop-check pipeline.
+
+Automatic build-driver selection treats a repository with neither manifest as
+"nothing to run" rather than a configuration error. That path must leave stdout
+silent, log a bounded structured `quality_gate_skip` record with
+`operation=quality_gate_skip`, `build_driver=auto`, and
+`manifests_missing=true`, and then continue to branch-state gates. Explicit
+`POST_TURN_BUILD_DRIVER=make` or `POST_TURN_BUILD_DRIVER=netsuke` remains
+strict: the selected manifest and executable must both exist.
 
 Configuration is represented by `Config` in
 `post_turn_quality_stop_hook/config.py`. Loading precedence is explicit config
@@ -118,6 +128,7 @@ The tests cover:
 - missing working-directory handling,
 - primary remote and Git-facts collection,
 - build-driver selection,
+- auto-mode quality-target skip logging when both build manifests are absent,
 - Make and Netsuke target discovery,
 - category-to-target mapping,
 - blocking output, branch-state gates, and PR-rebase integration,

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -30,7 +30,7 @@ small pipeline:
 9. Run available quality targets and emit a Claude Code blocking response on
    failure.
 10. Run branch-state gates for uncommitted changes, unpushed commits, protected
-   branch commit and push avoidance, and PR rebase requirements.
+    branch commit and push avoidance, and PR rebase requirements.
 
 The main state carrier is `HookState`. It keeps user-facing failure output
 consistent by collecting the diff base, changed files, categories, selected

--- a/docs/execplans/enforce-rebase.md
+++ b/docs/execplans/enforce-rebase.md
@@ -271,6 +271,11 @@ in `Decision Log` and asking the user for direction.
   some public helper docstrings lacked NumPy-style sections, and the rebase
   templates still needed tighter configured-base wording and wrapping.
   Date/Author: 2026-06-07, implementation agent.
+- Discovery: the robust Makefile/Netsukefile follow-up clarified that absence
+  of both build manifests is not a hook failure in automatic driver mode. It is
+  treated as a quality-target skip, emits bounded structured telemetry, and
+  then continues to branch-state gates. Date/Author: 2026-07-06, implementation
+  agent.
 
 ## Decision log
 
@@ -338,6 +343,16 @@ in `Decision Log` and asking the user for direction.
   intentionally broadens code-file coverage beyond Python, TypeScript, and Rust
   while keeping change-scoped target execution. Date/Author: 2026-06-06,
   implementation agent.
+- Decision: in automatic build-driver mode, treat a repository with neither
+  `Netsukefile` nor `Makefile` as having no quality targets to run rather than
+  as a configuration error. Log a structured `quality_gate_skip` record with
+  `operation=quality_gate_skip`, `build_driver=auto`, and
+  `manifests_missing=true`, then continue to branch-state gates. Rationale:
+  missing individual targets already skip gracefully, and repositories without
+  either manifest should not fail the stop hook solely because there is no
+  repository-native quality driver. Explicit `POST_TURN_BUILD_DRIVER=make` and
+  `POST_TURN_BUILD_DRIVER=netsuke` remain strict because those settings are
+  deliberate configuration. Date/Author: 2026-07-06, implementation agent.
 - Decision: implement the PR lookup as an optional best-effort gate.
   Rationale: the hook contract requires missing remotes, missing tokens, and
   lookup timeouts to skip the PR gate rather than block the stop. The new
@@ -973,3 +988,9 @@ the bundled Jinja rebase template, and a PR-base-ahead gate that renders the
 template when the PR base has advanced. Tests cover URL parsing, template
 equivalence, rendered typecheck inclusion, blocking behaviour, and graceful
 skip behaviour when primary remote information is unavailable.
+
+Revision 9 (2026-07-06): The robust build-driver follow-up documented and
+instrumented the automatic no-manifest quality skip. Auto mode now treats a
+repository with neither `Netsukefile` nor `Makefile` as having no quality
+targets to run, logs stable skip telemetry, and continues to branch-state
+gates. Explicit driver overrides remain strict.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -262,8 +262,10 @@ Git repository, or no changed files match the supported extensions.
 
 ### The hook cannot find a build driver
 
-In automatic driver mode, repositories without `Netsukefile` or `Makefile` skip
-repository quality targets and continue with branch-state gates. For explicit
+In automatic driver mode, the hook skips repository quality targets and
+continues with branch-state gates only when neither `Netsukefile` nor
+`Makefile` exists. When a supported manifest exists but its matching executable
+is unavailable, automatic mode still reports a build-driver error. For explicit
 driver selection, ensure the matching manifest and executable both exist.
 
 ### A target is skipped

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -100,7 +100,8 @@ driver. Automatic selection uses this order:
 
 1. Use Netsuke when `Netsukefile` exists and `netsuke` is available on `PATH`.
 2. Otherwise use Make when `Makefile` exists and `make` is available on `PATH`.
-3. Otherwise block with a build-driver selection error.
+3. Otherwise skip repository quality targets and continue with branch-state
+   gates.
 
 Set `POST_TURN_BUILD_DRIVER` to override automatic selection:
 
@@ -257,9 +258,9 @@ Git repository, or no changed files match the supported extensions.
 
 ### The hook cannot find a build driver
 
-Add a `Netsukefile` and install `netsuke`, or add a `Makefile` and ensure
-`make` is available on `PATH`. For explicit driver selection, ensure the
-matching manifest and executable both exist.
+In automatic driver mode, repositories without `Netsukefile` or `Makefile` skip
+repository quality targets and continue with branch-state gates. For explicit
+driver selection, ensure the matching manifest and executable both exist.
 
 ### A target is skipped
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -100,8 +100,12 @@ driver. Automatic selection uses this order:
 
 1. Use Netsuke when `Netsukefile` exists and `netsuke` is available on `PATH`.
 2. Otherwise use Make when `Makefile` exists and `make` is available on `PATH`.
-3. Otherwise skip repository quality targets and continue with branch-state
-   gates.
+3. When neither `Netsukefile` nor `Makefile` exists, skip repository quality
+   targets and continue with branch-state gates.
+
+Automatic mode still reports an error when manifests are present but no usable
+build driver remains, such as when the only manifest's matching executable is
+missing.
 
 Set `POST_TURN_BUILD_DRIVER` to override automatic selection:
 

--- a/post_turn_quality_stop_hook/driver.py
+++ b/post_turn_quality_stop_hook/driver.py
@@ -249,7 +249,9 @@ def select_build_driver(
     Returns
     -------
     tuple[BuildDriver | None, str | None]
-        Selected build driver and error message, if no driver can be selected.
+        ``(driver, None)`` when a driver is selected, ``(None, error)`` when
+        selection fails, or ``(None, None)`` when automatic selection finds
+        neither supported manifest and quality targets should be skipped.
 
     """
     requested_driver = options.build_driver.strip().lower()
@@ -295,7 +297,10 @@ def _select_auto_driver(
     Returns
     -------
     tuple[BuildDriver | None, str | None]
-        Selected driver and error message, if any.
+        ``(driver, None)`` when automatic discovery selects a driver,
+        ``(None, error)`` when manifests are present but no usable driver
+        remains, or ``(None, None)`` when neither supported manifest exists and
+        quality targets should be skipped.
 
     """
     selected: BuildDriver | None = None

--- a/post_turn_quality_stop_hook/driver.py
+++ b/post_turn_quality_stop_hook/driver.py
@@ -305,6 +305,8 @@ def _select_auto_driver(
         selected = availability.netsuke
     elif availability.has_makefile and availability.has_make:
         selected = availability.make
+    elif not availability.has_netsukefile and not availability.has_makefile:
+        selected = None
     elif availability.has_unusable_netsukefile and not availability.has_makefile:
         error = _driver_error(
             availability.netsuke,

--- a/post_turn_quality_stop_hook/git.py
+++ b/post_turn_quality_stop_hook/git.py
@@ -8,7 +8,7 @@ changed-file enumeration, and working-tree queries.
 from __future__ import annotations
 
 import os
-import subprocess  # noqa: S404
+import subprocess  # ruff:ignore[suspicious-subprocess-import]
 from pathlib import Path
 
 
@@ -62,7 +62,7 @@ def run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
 
     """
     try:
-        return subprocess.run(  # noqa: S603  # valid: command and args are controlled (no shell, no user-supplied command strings).
+        return subprocess.run(  # ruff:ignore[subprocess-without-shell-equals-true]  # valid: command and args are controlled (no shell, no user-supplied command strings).
             cmd,
             cwd=str(cwd),
             text=True,

--- a/post_turn_quality_stop_hook/github.py
+++ b/post_turn_quality_stop_hook/github.py
@@ -7,7 +7,7 @@ import dataclasses
 import os
 import re
 import shutil
-import subprocess  # noqa: S404
+import subprocess  # ruff:ignore[suspicious-subprocess-import]
 import typing as typ
 
 import github3
@@ -129,7 +129,7 @@ def github_token() -> str | None:
         return None
 
     try:
-        token = subprocess.run(  # noqa: S603  # command argv is fixed and read-only.
+        token = subprocess.run(  # ruff:ignore[subprocess-without-shell-equals-true]  # command argv is fixed and read-only.
             [gh_bin, "auth", "token"],
             text=True,
             capture_output=True,

--- a/post_turn_quality_stop_hook/pipeline.py
+++ b/post_turn_quality_stop_hook/pipeline.py
@@ -551,6 +551,18 @@ def _log_branch_gate_outcome(
     )
 
 
+def _log_quality_gate_skip() -> None:
+    """Log bounded quality-gate skip telemetry without changing hook stdout."""
+    logger.info(
+        "quality_gate_skip",
+        extra={
+            "operation": "quality_gate_skip",
+            "build_driver": "auto",
+            "manifests_missing": True,
+        },
+    )
+
+
 def pr_rebase_check(repo: Path, state: HookState, options: StopCheckOptions) -> int:
     """Block the stop when the open pull request base is ahead of this branch.
 
@@ -677,6 +689,7 @@ def run_quality_checks_if_needed(
     driver, err = select_build_driver(repo, options)
     if driver is None:
         if err is None:
+            _log_quality_gate_skip()
             return None
         return fail_state(state, err)
 

--- a/post_turn_quality_stop_hook/pipeline.py
+++ b/post_turn_quality_stop_hook/pipeline.py
@@ -676,6 +676,8 @@ def run_quality_checks_if_needed(
 
     driver, err = select_build_driver(repo, options)
     if driver is None:
+        if err is None:
+            return None
         return fail_state(state, err)
 
     rc = evaluate_changes(state, repo, options.max_out, driver)

--- a/post_turn_quality_stop_hook/pipeline.py
+++ b/post_turn_quality_stop_hook/pipeline.py
@@ -116,7 +116,7 @@ class BranchStateGateDecision:
 
     @property
     def should_block(self) -> bool:
-        """Return whether this decision should stop later gate evaluation."""
+        """Whether this decision should stop later gate evaluation."""
         return self.outcome == "block"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,36 +65,36 @@ select = [
     "ANN",
     "C90",
     "PLR",
-    "PLE4703",
-    "PLR0202",
-    "PLR0203",
-    "PLR0914",
-    "PLR0916",
-    "PLR1702",
-    "PLR6104",
-    "PLR6201",
-    "PLR6301",
-    "PLW0108",
-    "RUF036",
-    "RUF053",
-    "RUF055",
-    "RUF064",
-    "RUF066",
+    "modified-iterating-set",
+    "no-classmethod-decorator",
+    "no-staticmethod-decorator",
+    "too-many-locals",
+    "too-many-boolean-expressions",
+    "too-many-nested-blocks",
+    "non-augmented-assignment",
+    "literal-membership",
+    "no-self-use",
+    "unnecessary-lambda",
+    "none-not-at-end-of-union",
+    "class-with-mixed-type-vars",
+    "unnecessary-regular-expression",
+    "non-octal-permissions",
+    "property-without-return",
 ]
 extend-ignore = [
-    "D203",  # Conflicts with D211; prefer enforcing no blank line before class docstring.
-    "D213",  # Conflicts with D212; keep summary on the first line.
+    "incorrect-blank-line-before-class",  # Conflicts with D211; prefer enforcing no blank line before class docstring.
+    "multi-line-summary-second-line",  # Conflicts with D212; keep summary on the first line.
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "**/test_*.py" = [
-    "D102",
-    "FBT001",
-    "PLR6301",
-    "S101",
-    "TC002",
+    "undocumented-public-method",
+    "boolean-type-hint-positional-argument",
+    "no-self-use",
+    "assert",
+    "typing-only-third-party-import",
 ]
-"tests/steps/*.py" = ["S101", "PLR0913", "PLR2004"]
+"tests/steps/*.py" = ["assert", "too-many-arguments", "magic-value-comparison"]
 
 [tool.ruff.lint.flake8-import-conventions]
 # Declare the banned `from` imports.

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess  # noqa: S404
+import subprocess  # ruff:ignore[suspicious-subprocess-import]
 from pathlib import Path
 from unittest import mock
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -218,6 +218,17 @@ class TestBuildDriverSelection:
         assert err is not None
         assert "netsuke not found" in err
 
+    def test_auto_skips_when_no_supported_manifest_exists(self, tmp_path: Path) -> None:
+        """No Makefile or Netsukefile in auto mode means no quality driver."""
+        with mock.patch.object(shutil, "which", return_value="/usr/bin/tool"):
+            driver, err = driver_mod.select_build_driver(
+                tmp_path,
+                state_mod.StopCheckOptions(always_fetch=False, max_out=12000),
+            )
+
+        assert driver is None
+        assert err is None
+
 
 class TestNetsukeTargets:
     """Tests for Netsuke target enumeration and execution."""
@@ -232,6 +243,27 @@ class TestNetsukeTargets:
             ])
         )
         assert targets == {"check-fmt", "lint", "markdownlint"}
+
+    def test_missing_requested_targets_skip_without_blocking(self) -> None:
+        """Absent requested targets are recorded but do not block the hook."""
+        state = state_mod.HookState(changed_files=["src/app.py"])
+        driver = driver_mod.BuildDriver("netsuke", "netsuke", "Netsukefile")
+        with (
+            mock.patch.object(
+                pipeline_mod,
+                "get_build_targets",
+                return_value=({"build"}, None),
+            ),
+            mock.patch.object(pipeline_mod, "run_build_targets") as mock_run_targets,
+        ):
+            rc = pipeline_mod.evaluate_changes(state, REPO, 12000, driver)
+
+        assert rc == 0
+        assert state.ok is True
+        assert state.targets_requested == ["check-fmt", "lint", "typecheck"]
+        assert state.targets_run == []
+        assert state.targets_skipped == ["check-fmt", "lint", "typecheck"]
+        mock_run_targets.assert_not_called()
 
     def test_markdown_changes_run_netsuke_markdownlint(self) -> None:
         state = state_mod.HookState(changed_files=["docs/users-guide.md"])

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import subprocess  # noqa: S404
+import subprocess  # ruff:ignore[suspicious-subprocess-import]
 from pathlib import Path
 from unittest import mock
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import subprocess  # noqa: S404
+import subprocess  # ruff:ignore[suspicious-subprocess-import]
 from pathlib import Path
 from unittest import mock
 

--- a/tests/test_git_facts.py
+++ b/tests/test_git_facts.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import subprocess  # noqa: S404
+import subprocess  # ruff:ignore[suspicious-subprocess-import]
 from pathlib import Path
 from unittest import mock
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -338,9 +338,12 @@ class TestRunStopChecksBranchStateGates:
         mock_uncommitted.assert_not_called()
         mock_unpushed.assert_not_called()
 
-    def test_branch_state_gates_run_without_build_driver(self) -> None:
+    def test_branch_state_gates_run_without_build_driver(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """No Makefile or Netsukefile skips quality gates in auto mode."""
         with (
+            caplog.at_level("INFO", logger=pipeline_mod.__name__),
             mock.patch.object(pipeline_mod, "repo_root", return_value=(REPO, None)),
             mock.patch.object(
                 pipeline_mod, "ensure_base_ref", return_value=(True, None, False)
@@ -388,6 +391,12 @@ class TestRunStopChecksBranchStateGates:
         mock_uncommitted.assert_called_once()
         mock_unpushed.assert_called_once()
         mock_rebase.assert_called_once()
+        assert any(
+            record.__dict__.get("operation") == "quality_gate_skip"
+            and record.__dict__.get("build_driver") == "auto"
+            and record.__dict__.get("manifests_missing") is True
+            for record in caplog.records
+        )
 
     def test_branch_state_gates_run_when_no_files_changed(self) -> None:
         """Branch-state gates still run when there are no changed files to lint."""

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-import subprocess  # noqa: S404
+import subprocess  # ruff:ignore[suspicious-subprocess-import]
 from pathlib import Path
 from unittest import mock
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -338,6 +338,57 @@ class TestRunStopChecksBranchStateGates:
         mock_uncommitted.assert_not_called()
         mock_unpushed.assert_not_called()
 
+    def test_branch_state_gates_run_without_build_driver(self) -> None:
+        """No Makefile or Netsukefile skips quality gates in auto mode."""
+        with (
+            mock.patch.object(pipeline_mod, "repo_root", return_value=(REPO, None)),
+            mock.patch.object(
+                pipeline_mod, "ensure_base_ref", return_value=(True, None, False)
+            ),
+            mock.patch.object(
+                pipeline_mod, "merge_base", return_value=("abc123", None)
+            ),
+            mock.patch.object(
+                pipeline_mod, "changed_files", return_value=(["src/foo.py"], None)
+            ),
+            mock.patch.object(
+                pipeline_mod, "select_build_driver", return_value=(None, None)
+            ),
+            mock.patch.object(pipeline_mod, "evaluate_changes") as mock_evaluate,
+            mock.patch.object(
+                pipeline_mod,
+                "uncommitted_changes_gate",
+                return_value=pipeline_mod.BranchStateGateDecision(
+                    gate="uncommitted_changes", outcome="pass"
+                ),
+            ) as mock_uncommitted,
+            mock.patch.object(
+                pipeline_mod,
+                "unpushed_commits_gate",
+                return_value=pipeline_mod.BranchStateGateDecision(
+                    gate="unpushed_commits", outcome="pass"
+                ),
+            ) as mock_unpushed,
+            mock.patch.object(
+                pipeline_mod, "pr_rebase_check", return_value=0
+            ) as mock_rebase,
+            mock.patch("shutil.which", return_value="/usr/bin/git"),
+        ):
+            rc = pipeline_mod.run_stop_checks(
+                REPO,
+                "origin/main",
+                state_mod.StopCheckOptions(
+                    always_fetch=False,
+                    max_out=12000,
+                ),
+            )
+
+        assert rc == 0, f"expected run_stop_checks rc 0 but got {rc!r}"
+        mock_evaluate.assert_not_called()
+        mock_uncommitted.assert_called_once()
+        mock_unpushed.assert_called_once()
+        mock_rebase.assert_called_once()
+
     def test_branch_state_gates_run_when_no_files_changed(self) -> None:
         """Branch-state gates still run when there are no changed files to lint."""
         with (


### PR DESCRIPTION
## Summary

This branch makes automatic build-driver discovery tolerant of repositories that do not provide either a `Makefile` or a `Netsukefile`. In that case, the stop hook now skips repository quality targets and continues with branch-state gates instead of reporting a hard build-driver failure.

It keeps explicit `make` and `netsuke` driver selection strict, so deliberately configured but unusable drivers still return actionable errors.

## Review walkthrough

- Start with [post_turn_quality_stop_hook/driver.py](https://github.com/leynos/post-turn-quality-stop-hook/blob/2e71aa3f031f2b57014051ae91fa573b0158ad3a/post_turn_quality_stop_hook/driver.py) to see how auto discovery now distinguishes an absent manifest pair from an unusable selected driver.
- Then review [post_turn_quality_stop_hook/pipeline.py](https://github.com/leynos/post-turn-quality-stop-hook/blob/2e71aa3f031f2b57014051ae91fa573b0158ad3a/post_turn_quality_stop_hook/pipeline.py) for the skip path that lets branch-state gates continue when no auto driver is available.
- Check [tests/test_driver.py](https://github.com/leynos/post-turn-quality-stop-hook/blob/2e71aa3f031f2b57014051ae91fa573b0158ad3a/tests/test_driver.py) and [tests/test_pipeline.py](https://github.com/leynos/post-turn-quality-stop-hook/blob/2e71aa3f031f2b57014051ae91fa573b0158ad3a/tests/test_pipeline.py) for regression coverage of missing manifests and missing requested targets.
- Finish with [docs/users-guide.md](https://github.com/leynos/post-turn-quality-stop-hook/blob/2e71aa3f031f2b57014051ae91fa573b0158ad3a/docs/users-guide.md) for the documented auto-mode behaviour.

## Validation

- `make fmt`: passed
- `make check-fmt`: passed
- `make lint`: passed
- `make typecheck`: passed
- `make markdownlint`: passed
- `make nixie`: passed
- `make test`: passed, `158 passed`

## Notes

No issue, roadmap task, or execplan was identified for this branch.

## References

- [Lody session](https://lody.ai/leynos/sessions/5fdd0bc0-175e-41e0-a89f-a32d95d7de9b)
