### PR TITLE
Reword should_block docstring for new ruff preview rule

### DIFF
--- a/post_turn_quality_stop_hook/pipeline.py
+++ b/post_turn_quality_stop_hook/pipeline.py
@@ -116,7 +116,7 @@ class BranchStateGateDecision:
 
     @property
     def should_block(self) -> bool:
-        """Return whether this decision should stop later gate evaluation."""
+        """Whether this decision should stop later gate evaluation."""
         return self.outcome == "block"
 
 


### PR DESCRIPTION
## Summary

Fixes the lint gate that has been red on `main` since 2026-06-27. CI installs ruff unpinned (`uv tool install ruff`), and with `preview = true` in `pyproject.toml` the newly released preview rule `property-docstring-starts-with-verb` flags the `should_block` property docstring in [`post_turn_quality_stop_hook/pipeline.py`](https://github.com/leynos/post-turn-quality-stop-hook/blob/fix-property-docstring-lint/post_turn_quality_stop_hook/pipeline.py). The docstring is reworded as a noun phrase; no behaviour changes.

This unblocks the `lint-test` check for #27 (which will be rebased onto this once merged).

## Validation

- `ruff check` (0.15.20, the version CI currently resolves) — clean.
- `ruff format --check` — clean.
- `ty check` — clean.
- `pytest -n auto` — 155 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
