### PR TITLE
Let Dependabot own the mutation-mutmut workflow pin

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -138,6 +138,42 @@ environment changes should exercise `parse_env`; CLI changes should exercise
 `parse_cli_args` and `main`; hook contract changes should assert captured
 standard output.
 
+### Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ## Packaging
 
 The project is a Python 3.14 package configured in `pyproject.toml` with

--- a/tests/test_workflow_contract.py
+++ b/tests/test_workflow_contract.py
@@ -3,14 +3,18 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests; this
 repository's caller is declarative configuration. These tests parse the
-caller with PyYAML and pin the contract it must uphold, so drift
-(repointing the pin at a branch, widening permissions, or losing the
-mutmut configuration) fails CI on the pull request rather than
-surfacing in a scheduled or manual run.
+caller with PyYAML and assert the contract it must uphold, so drift
+(repointing the reference at a branch, widening permissions, or losing
+the mutmut configuration) fails CI on the pull request rather than
+surfacing in a scheduled or manual run. The caller must reference the
+correct reusable workflow at a commit SHA; Dependabot owns the SHA
+value, so these tests assert the shape of the pin, not which commit it
+names.
 """
 
 from __future__ import annotations
 
+import re
 import typing as typ
 from pathlib import Path
 
@@ -30,18 +34,12 @@ pytestmark = pytest.mark.skipif(
     "inside mutmut's mutants/ sandbox, which does not copy .github/)",
 )
 
-#: The commit SHA of leynos/shared-actions carrying the validated
-#: mutation-mutmut reusable workflow. Bump the caller and this test
-#: together.
-PINNED_SHA = "859416a90eb3987b46a57682c5d6b8964ad3f0a6"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-mutmut.yml@" + PINNED_SHA
+#: The reusable workflow the caller must reference, pinned to a full
+#: 40-hex commit SHA. Dependabot owns the SHA value; this test does
+#: not pin it.
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-mutmut\.yml@[0-9a-f]{40}$"
 )
-
-#: Length of a full git commit SHA; anything shorter is a branch, tag,
-#: or abbreviated pin.
-FULL_SHA_LENGTH = 40
 
 #: The caller inputs this repository relies on; anything else must use
 #: the reusable workflow's defaults.
@@ -80,26 +78,15 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return typ.cast("dict[str, object]", jobs_map["mutation"])
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_full_sha() -> None:
+    """The job must call mutation-mutmut.yml pinned to a full commit SHA."""
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
     assert isinstance(uses, str), f"jobs.mutation.uses must be a string, got {uses!r}"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-mutmut.yml", (
-        f"jobs.mutation.uses must reference mutation-mutmut.yml, got {path!r}"
-    )
-    assert len(ref) == FULL_SHA_LENGTH, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump the workflow and this test together"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference mutation-mutmut.yml pinned to a "
+        f"full 40-character lowercase-hex commit SHA, not a branch or tag: "
+        f"{uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- Replace the exact-SHA equality assertion in the mutation-mutmut
  workflow contract test with a shape assertion: the caller must
  reference `leynos/shared-actions/.github/workflows/mutation-mutmut.yml`
  pinned to a full 40-character commit SHA, but the test no longer
  names which SHA.
- This hands ownership of the pinned commit to Dependabot: a routine
  bump PR from Dependabot will no longer fail this test, because the
  test never hard-codes the current value.
- All other structural assertions are unchanged: job permissions,
  workflow-level default permissions, concurrency group and
  cancel-in-progress, triggers (schedule and bare workflow_dispatch),
  and the `with:` block contents.
- Document the policy in the developers' guide (new "Workflow pins and
  Dependabot" subsection under "Testing strategy") so future contract
  tests follow the same shape.

## Review walkthrough

- `tests/test_workflow_contract.py`: dropped `PINNED_SHA`,
  `EXPECTED_USES`, and `FULL_SHA_LENGTH`; added a single `USES_RE`
  regex (`^leynos/shared-actions/\.github/workflows/mutation-mutmut\.yml@[0-9a-f]{40}$`)
  and one test, `test_uses_reference_is_pinned_to_a_full_sha`, that
  matches it. Updated the module docstring to describe the new
  contract instead of "pin the contract".
- `docs/developers-guide.md`: added the policy subsection, matching
  the estate-wide canonical wording.
- Did not touch the workflow file itself
  (`.github/workflows/mutation-testing.yml`) or its current pinned
  SHA — Dependabot continues to own bumping that value.
- `.github/dependabot.yml` already has a `github-actions` ecosystem
  entry with `directory: "/"`, so no change was needed there.

## Validation

- `uv run pytest tests/test_workflow_contract.py -v` — all 6 tests
  pass against the current pinned SHA.
- Reasoned through the regex against a hypothetical different 40-hex
  SHA: it only constrains the path and the hex-digit shape/length, not
  the digits' value, so any full-length commit SHA on the correct path
  satisfies it.
- `make lint`, `make typecheck`, `make markdownlint`, `make test`
  (161 passed) all pass locally.
