### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -140,15 +140,15 @@ standard output.
 
 ### Workflow pins and Dependabot
 
-Dependabot owns the upgrade of GitHub Actions and reusable workflows,
-including calls into `leynos/shared-actions`. Contract tests that assert a
-caller's exact commit SHA create a lockstep dependency: every time Dependabot
-opens a bump PR, the test fails until a human edits the pinned constant to
-match. That defeats the purpose of automated dependency updates and turns a
-routine bump into a manual chore.
+Dependabot owns the upgrade of GitHub Actions and reusable workflows, including
+calls into `leynos/shared-actions`. Contract tests that assert a caller's exact
+commit SHA create a lockstep dependency: every time Dependabot opens a bump PR,
+the test fails until a human edits the pinned constant to match. That defeats
+the purpose of automated dependency updates and turns a routine bump into a
+manual chore.
 
-Contract tests may still verify the *shape* of a reusable-workflow caller.
-They must not verify the specific SHA value.
+Contract tests may still verify the *shape* of a reusable-workflow caller. They
+must not verify the specific SHA value.
 
 - Do assert the workflow references the correct reusable workflow path.
 - Do assert the ref is pinned to a full 40-character commit SHA, not a
@@ -173,6 +173,71 @@ def test_uses_pinned_full_sha(caller_step):
 If a workflow's behaviour genuinely depends on a feature only present from a
 particular commit onwards, express that as a comment or a changelog note, not
 as a test assertion on the SHA string.
+
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow,
+[`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-mutmut.yml`. The heavy
+lifting — running `mutmut` and summarizing survivors — lives in
+`shared-actions`; this repository carries only declarative configuration. The
+run is **informational only**: it never gates a pull request. Survivors are
+reported through the job summary and downloadable artefacts so they can be
+triaged into tests, not enforced as a blocking check. The mutation targets and
+test selection themselves are configured in `[tool.mutmut]` in `pyproject.toml`
+(`source_paths`, `pytest_add_cli_args_test_selection`, `also_copy`).
+
+The workflow runs in two modes. A daily schedule (12:20 UTC) fires a
+change-scoped run that mutates only the source files touched within the
+detection window, so quiet days are cheap no-ops. A manual dispatch (the
+Actions "Run workflow" control) mutates the whole package; select a branch in
+that control to exercise a feature branch. Dispatch declares no inputs of its
+own — the run-workflow control's branch selector is how a feature branch is
+exercised.
+
+The caller passes the configuration inputs this flat-layout package needs:
+
+- `paths` — `post_turn_quality_stop_hook/`, the change-detection glob that
+  decides whether a scheduled run has anything to mutate.
+- `module-prefix-strip` — set to an empty string because the mutable source
+  lives at the repository root rather than under a `src/` layout.
+- `python-version` — pinned to `3.14` because this project's
+  `requires-python` floor exceeds the reusable workflow's default Python
+  version.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test asserts only that the pin is a full
+commit SHA, not a particular value, so Dependabot bumps it automatically
+without any accompanying test edit (see
+[Workflow pins and Dependabot](#workflow-pins-and-dependabot) above).
+
+Because the caller is configuration rather than code,
+`tests/test_workflow_contract.py` pins the shape it must uphold, failing the
+pull request when the caller drifts — repointing the pin at a branch, widening
+the token scope, or dropping a configuration input — rather than letting the
+breakage surface only in a scheduled run. The module self-skips when the
+workflow file is absent: mutmut copies sources into a `mutants/` sandbox that
+omits `.github/`, so the contract test does not run there. Run it locally with:
+
+```bash
+uv run pytest tests/test_workflow_contract.py -v
+```
+
+The test validates:
+
+- the `uses:` reference targets `mutation-mutmut.yml` pinned to a full commit
+  SHA;
+- the `with:` block carries exactly the expected `paths`,
+  `module-prefix-strip`, and `python-version` configuration;
+- job permissions are least-privilege (`contents: read`, `id-token: write`)
+  and the workflow-level default token scope is empty;
+- `concurrency` serializes runs per ref without cancelling one in progress;
+  and
+- the triggers keep the daily schedule and a plain `workflow_dispatch` with
+  no legacy branch input.
 
 ## Packaging
 


### PR DESCRIPTION
## Summary

Adds a `## Mutation-testing workflow contract tests` section to
[`docs/developers-guide.md`](docs/developers-guide.md), placed after the
existing "Workflow pins and Dependabot" subsection under "Testing strategy".
It documents:

- what `.github/workflows/mutation-testing.yml` delegates to
  (`leynos/shared-actions/.github/workflows/mutation-mutmut.yml`) and the
  informational, non-gating nature of the run;
- the two run modes (daily change-scoped schedule, manual whole-package
  dispatch);
- the caller's actual `with:` inputs (`paths`, `module-prefix-strip`,
  `python-version` — the only three this repository sets);
- `tests/test_workflow_contract.py`: it is **shape-only** (a `USES_RE`
  pattern asserting `mutation-mutmut.yml@[0-9a-f]{40}`, not a hard-coded SHA
  constant), so Dependabot's SHA bumps never require a test edit;
- its `skipif` guard, which self-skips when
  `.github/workflows/mutation-testing.yml` is absent (mutmut's `mutants/`
  sandbox omits `.github/`);
- the real local command, confirmed by running it:
  `uv run pytest tests/test_workflow_contract.py -v` (6 tests pass).

## Permutation

Permutation C (Python/mutmut), reconciled to this repository's actual caller
inputs and test module name/path.

## Roadmap / execplan

No `docs/roadmap.md` exists, and neither execplan under `docs/execplans/`
(`enforce-rebase.md`, `protect-branches.md`) references mutation testing —
no roadmap or execplan tracking applies to this change.

## Docs lint

- `make markdownlint` — 0 errors (16 files).
- `make spelling` (typos, en-GB-oxendict) — clean; the incidental
  `typos.toml` regeneration from the shared dictionary refresh was reverted
  to keep this PR scoped to the docs change.
- `make nixie` — all diagrams validated successfully.
- `mdformat-all` was run per the project's documented Markdown workflow; it
  also re-wrapped the adjacent "Workflow pins and Dependabot" subsection
  (no content change, wrapping only).

## TOC

`docs/developers-guide.md` has no table of contents or index list, so no
cross-link was added.
